### PR TITLE
add window.getX() and getY() methods

### DIFF
--- a/MacGap/Classes/Window.h
+++ b/MacGap/Classes/Window.h
@@ -14,6 +14,8 @@
 - (void) move:(NSDictionary *)properties;
 - (void) resize:(NSDictionary *) properties;
 - (Boolean) isMaximized;
+- (CGFloat) getX;
+- (CGFloat) getY;
 - (void) maximize;
 - (void) restore;
 - (void) toggleFullscreen;

--- a/MacGap/Classes/Window.m
+++ b/MacGap/Classes/Window.m
@@ -39,6 +39,16 @@
     return a.origin.x == b.origin.x && a.origin.y == b.origin.y && a.size.width == b.size.width && a.size.height == b.size.height;
 }
 
+- (CGFloat) getX {
+    NSRect frame = [self.webView window].frame;
+    return frame.origin.x;
+}
+
+- (CGFloat) getY {
+    NSRect frame = [self.webView window].frame;
+    return frame.origin.y;
+}
+
 - (void) move:(NSDictionary *)properties
 {
     NSRect frame = [self.webView window].frame;


### PR DESCRIPTION
Simple addition to allow javascript access to get the X,Y coordinates of the window. This allows amongst other things the ability for javascript to move the window around when an element in the DOM is dragged. I tested this using code such as:

```
var dragging = false;
document.onmousemove = function() {
  if (!dragging) return;
  macgap.window.move({
    x: macgap.window.getX() + event.clientX - xstart,
    y: macgap.window.getY() +ystart - event.clientY,
  });
}

document.onmousedown = function(){
  dragging = true;
  xstart = event.clientX;
  ystart = event.clientY;
}

document.onmouseup = function(){
  dragging = false;
}
```
